### PR TITLE
Init context page

### DIFF
--- a/content/context.md
+++ b/content/context.md
@@ -1,0 +1,19 @@
+---
+title: Context
+---
+
+Codes of conduct help make explicit what behaviors are welcome and unwelcome in a community. With so-called "Artificial Intelligence" (AI) tools spreading in usage, new behaviors show up that we may feel uncomfortable with. [Maybe we can say that this is about taking into account these new behaviors in the conversation about what makes our spaces safe and welcoming for everyone participating in them]
+
+For ease of conversation, we use AI but it can be replaced with LLMs as well.
+
+## Problem
+
+We explore new behaviors that are the result of the increased use of AI tools. This can include people using AI to write tasks, outline strategies, or otherwise using AI tools to produce their work for them. 
+
+The use of AI tools without consent of the people involved may result in harm. For example, group dynamics can be drastically altered by adding pre-generated content that is unverified, or the addition of an AI assistant into a conversation without consent. 
+
+## Solution
+
+We articulate a new section for codes of conduct. Some usage of AI may not be an individual choice only. This will be a concrete departure point that can be adopted or utilized for further discussions.
+
+**We write an AI Covenant and release it under a CC0 Public Domain Dedication**. People can take this covenant and copy/edit it for their own use in existing codes of conduct.

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -18,9 +18,9 @@ markup:
 
 menu:
   main:
-    - name: Docs
-      pageRef: /docs
-      weight: 1
+    - name: Context
+      pageRef: /context
+      weight: 2
     - name: About
       pageRef: /about
       weight: 2


### PR DESCRIPTION
This PR ports over the context from the hackday into its own page, to provide more details.

We can continue the discussion here on whether we want to keep, remove, or add any information.