### PR TITLE
Update about page

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -2,8 +2,15 @@
 title: About
 ---
 
-We want to make it easier for people to use AI responsibly in their communities. Since the launch of generative AI models like ChatGPT and integrations like GitHub Copilot, these discussions are being had in communities. As this development is still ongoing, we provide the AI Covenant as an addition to the Contributor Covenant.
 
-Responsible use of AI is not one-size fits all - the covenant is a starting point for your communities. 
+"Artificial Intelligence" (AI) tools are spreading in usage, and with that new behaviors show up that affect communities. People in our communities may feel unsafe or not welcome as a result of how AI tools are used. The use of AI tools without consent of the people involved may even result in harm. For example, group trust can be breached by adding an AI assistant to a meeting or using generated content without clearly labeling it as such.
 
-We created the initial version of the AI Covenant during the hackday at the Collaborations Workshop 2024. The original idea for an "AI Code of Conduct" came from Eli Chadwick, Matt Craddock. Riva Quiroga and Chris Hartgerink expanded on the idea and built the website that you are looking at now.
+The AI Covenant sets out shared norms for responsible use of AI. We want to make sure our community spaces are safe and welcoming also when AI tools are used. The AI Covenant is inspired by [the Contributor Covenant]() and aims to be copy-pasted into your own code of conduct. The AI Covenant is available under a CC0 Public Domain Dedication --- this means you can adjust it as you see fit. After all, the AI Covenant is a departure point and discussion starter.
+
+The idea for this "AI Code of Conduct" originated during the Collaborations Workshop 2024, in conversations between Eli Chadwick and Matt Craddock.. Riva Quiroga and Chris Hartgerink expanded on the idea and built the website that you are looking at now.
+
+Codes of conduct help make explicit what behaviors are welcome and unwelcome in a community. With so-called "Artificial Intelligence" (AI) tools spreading in usage, new behaviors show up that we may feel uncomfortable with. [Maybe we can say that this is about taking into account these new behaviors in the conversation about what makes our spaces safe and welcoming for everyone participating in them]
+
+## Contributing
+
+We love for this discussion to be broader than just our small bubble. Edit the pages freely and open issues without restraint - when you participate in the discussion with clarity of how your community is affected by the use of AI, we can all learn how to use AI more responsibly.

--- a/content/about.md
+++ b/content/about.md
@@ -5,7 +5,7 @@ title: About
 
 "Artificial Intelligence" (AI) tools are spreading in usage, and with that new behaviors show up that affect communities. People in our communities may feel unsafe or not welcome as a result of how AI tools are used. The use of AI tools without consent of the people involved may even result in harm. For example, group trust can be breached by adding an AI assistant to a meeting or using generated content without clearly labeling it as such.
 
-The AI Covenant sets out shared norms for responsible use of AI. We want to make sure our community spaces are safe and welcoming also when AI tools are used. The AI Covenant is inspired by [the Contributor Covenant]() and aims to be copy-pasted into your own code of conduct. The AI Covenant is available under a CC0 Public Domain Dedication --- this means you can adjust it as you see fit. After all, the AI Covenant is a departure point and discussion starter.
+The AI Covenant sets out shared norms for responsible use of AI. We want to make sure our community spaces are safe and welcoming also when AI tools are used. The AI Covenant is inspired by [the Contributor Covenant](https://www.contributor-covenant.org/) and aims to be copy-pasted into your own code of conduct. The AI Covenant is available under a CC0 Public Domain Dedication --- this means you can adjust it as you see fit. After all, the AI Covenant is a departure point and discussion starter.
 
 The idea for this "AI Code of Conduct" originated during the Collaborations Workshop 2024, in conversations between Eli Chadwick and Matt Craddock.. Riva Quiroga and Chris Hartgerink expanded on the idea and built the website that you are looking at now.
 

--- a/content/about.md
+++ b/content/about.md
@@ -9,7 +9,7 @@ The AI Covenant sets out shared norms for responsible use of AI. We want to make
 
 The idea for this "AI Code of Conduct" originated during the Collaborations Workshop 2024, in conversations between Eli Chadwick and Matt Craddock.. Riva Quiroga and Chris Hartgerink expanded on the idea and built the website that you are looking at now.
 
-Codes of conduct help make explicit what behaviors are welcome and unwelcome in a community. With so-called "Artificial Intelligence" (AI) tools spreading in usage, new behaviors show up that we may feel uncomfortable with. [Maybe we can say that this is about taking into account these new behaviors in the conversation about what makes our spaces safe and welcoming for everyone participating in them]
+Codes of conduct help make explicit what behaviors are welcome and unwelcome in a community. With so-called "Artificial Intelligence" (AI) tools spreading in usage, new behaviors show up that we may feel uncomfortable with or can be a harm for members of the community.
 
 ## Contributing
 

--- a/content/about.md
+++ b/content/about.md
@@ -1,6 +1,9 @@
 ---
 title: About
-type: about
 ---
 
-This is the about page.
+We want to make it easier for people to use AI responsibly in their communities. Since the launch of generative AI models like ChatGPT and integrations like GitHub Copilot, these discussions are being had in communities. As this development is still ongoing, we provide the AI Covenant as an addition to the Contributor Covenant.
+
+Responsible use of AI is not one-size fits all - the covenant is a starting point for your communities. 
+
+We created the initial version of the AI Covenant during the hackday at the Collaborations Workshop 2024. The original idea for an "AI Code of Conduct" came from Eli Chadwick, Matt Craddock. Riva Quiroga and Chris Hartgerink expanded on the idea and built the website that you are looking at now.


### PR DESCRIPTION
This PR adds a bit of history to the about page. This is different from the context page, which highlights the problem we're trying to address. Maybe we can integrate about and context to simplify the page structure and provide fewer sources of information+confusion? :-)


